### PR TITLE
make posix compliant

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,5 +1,7 @@
-function set_title(title)
-	vis:command(string.format(":!echo -ne '\\033]0;%s\\007'", title))
+require('vis')
+
+local function set_title(title)
+	vis:command(string.format(":!printf '\\033]0;%s\\007'", title))
 end
 
 vis.events.subscribe(vis.events.WIN_OPEN, function(win)


### PR DESCRIPTION
`-ne` echo option is not recognized by all shells

According to https://pubs.opengroup.org/onlinepubs/9699919799/utilities/echo.html#top, section `APPLICATION USAGE`, it is advised to prefer `printf` over `echo` for cross-platform support across POSIX compliant platforms.